### PR TITLE
feat: 导航栏头像改为鼠标悬浮延时显示菜单

### DIFF
--- a/src/components/Layout/HeaderComponent.vue
+++ b/src/components/Layout/HeaderComponent.vue
@@ -47,7 +47,7 @@
                 </template>
                 <span>面板设置</span>
             </n-popover>
-            <n-dropdown trigger="click" :options="userDropdownOptions">
+            <n-dropdown trigger="hover" :options="userDropdownOptions" :show-delay="300">
                 <n-button quaternary size="large">
                     <n-avatar
                         v-if="userInfo?.userimg"


### PR DESCRIPTION
## 功能描述

将导航栏右侧头像的下拉菜单触发方式从点击改为鼠标悬浮延时显示，提升用户体验。

## 具体修改

- 修改了 `src/components/Layout/HeaderComponent.vue` 文件
- 将 `n-dropdown` 组件的 `trigger` 属性从 `click` 改为 `hover`
- 添加了 `:show-delay="300"` 属性，设置 300 毫秒的延时

## 影响范围

- 仅影响导航栏的交互逻辑，不改变其他功能
- 保持了原有的菜单内容和样式不变

## 测试情况

- 已在本地环境测试，功能正常
- 开发服务器运行正常，无错误