### PR TITLE
chore: 将API基础URL和返回URL更新为生产环境地址

### DIFF
--- a/src/api/v2/axios/axiosInstance.ts
+++ b/src/api/v2/axios/axiosInstance.ts
@@ -23,7 +23,7 @@ export class ApiError extends Error {
 
 // 创建 Axios 实例
 const axiosInstance = axios.create({
-    baseURL: 'http://localhost:8111',
+    baseURL: 'https://cf-v2.uapis.cn',
     timeout: 30000,
     withCredentials: true,
     headers: {

--- a/src/views/Sign/index.vue
+++ b/src/views/Sign/index.vue
@@ -33,8 +33,8 @@ import { computed, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import api from '@/api';
 
-const apiBaseUrl = 'http://localhost:8111';
-const returnUrl = 'http://localhost:5174/home';
+const apiBaseUrl = 'https://cf-v2.uapis.cn';
+const returnUrl = 'https://panel.chmlfrp.net/home';
 
 const authorizeUrl = computed(() => `${apiBaseUrl}/sso/authorize?return_url=${encodeURIComponent(returnUrl)}`);
 


### PR DESCRIPTION
将本地开发环境地址替换为线上生产环境地址，确保应用在生产环境中正确连接到后端API和重定向到正确的面板页面。