### PR TITLE
docs: 在用户页面提示信息中添加“点击跳转”说明

### DIFF
--- a/src/pages/User/index.vue
+++ b/src/pages/User/index.vue
@@ -11,13 +11,13 @@
                         style="margin-bottom: 8px; cursor: pointer"
                         @click="openRealnameConsole"
                     >
-                        您尚未实名，请前往轻爪账户控制台完成实名认证。根据中国法律规定，未实名将无法使用ChmlFrp提供的服务。
+                        您尚未实名，请前往轻爪账户控制台（点击跳转）完成实名认证。根据中国法律规定，未实名将无法使用ChmlFrp提供的服务。
                         <template #action>
                             <n-button text type="warning" @click.stop="openRealnameConsole">前往实名</n-button>
                         </template>
                     </n-alert>
                     <n-alert type="info" title="提示" style="cursor: pointer" @click="openAccountConsole">
-                        如果要更改账户信息，请前往轻爪账户控制台
+                        如果要更改账户信息，请前往轻爪账户控制台（点击跳转）
                         <template #action>
                             <n-button text type="primary" @click.stop="openAccountConsole">前往控制台</n-button>
                         </template>


### PR DESCRIPTION
在实名认证和账户信息提示中明确指示可点击跳转，提升用户操作引导的清晰度